### PR TITLE
New single player mode "Clean garbage"

### DIFF
--- a/android/assets/i18n/strings.properties
+++ b/android/assets/i18n/strings.properties
@@ -162,6 +162,7 @@ goalModelSprint=Clear 40 lines as fast as possible.
 goalModelMultiplayer=Live longer than your opponents!
 goalModelTurnBattle=Send garbage to your opponent and survive it, turn by turn!
 goalModelFreeze=Survive unpredictable gravity changes. You can even freeze the gravity for some time!
+goalModelCleanGarbage=Clear garbage lines as fast as possible.
 exitWarningTurnBattle=If you exit your turn, you will not be able to play it again and you will need to resign the \
   match. Are you sure?
 lockModelSprint=To unlock Sprint Mode, clear 40 lines in Marathon or accomplish Mission 10.
@@ -198,6 +199,7 @@ labelModel_typeB=Clean
 labelModel_special=Speciality
 labelModel_minTetroSet=Parsimony
 labelModel_garbage=Garbage
+labelModel_cleanGarbage=Clean Garbage
 labelModel_blocks=Mass
 labelRoundScore=Round
 labelBestScore=Best

--- a/core/src/de/golfgl/lightblocks/menu/SimpleGameModeGroup.java
+++ b/core/src/de/golfgl/lightblocks/menu/SimpleGameModeGroup.java
@@ -12,6 +12,7 @@ import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.Timer;
 
 import de.golfgl.lightblocks.LightBlocksGame;
+import de.golfgl.lightblocks.model.CleanGarbageModel;
 import de.golfgl.lightblocks.model.MarathonModel;
 import de.golfgl.lightblocks.model.ModernFreezeModel;
 import de.golfgl.lightblocks.model.PracticeModel;
@@ -21,6 +22,7 @@ import de.golfgl.lightblocks.scene2d.FaRadioButton;
 import de.golfgl.lightblocks.scene2d.FaTextButton;
 import de.golfgl.lightblocks.scene2d.MyStage;
 import de.golfgl.lightblocks.scene2d.ScaledLabel;
+import de.golfgl.lightblocks.scene2d.TouchableSlider;
 import de.golfgl.lightblocks.scene2d.VetoDialog;
 import de.golfgl.lightblocks.input.PlayGesturesInput;
 import de.golfgl.lightblocks.screen.PlayScreen;
@@ -322,6 +324,86 @@ public abstract class SimpleGameModeGroup extends Table implements SinglePlayerS
         protected void savePreselectionSettings() {
             super.savePreselectionSettings();
             app.localPrefs.saveLastUsedModeType(modeType.getValue());
+        }
+    }
+
+    public static class CleanGarbageModeGroup extends SimpleGameModeGroup {
+        protected TouchableSlider garbageSizeSlider;
+
+        public CleanGarbageModeGroup(SinglePlayerScreen myParentScreen, LightBlocksGame app) {
+            super(myParentScreen, app);
+        }
+
+        @Override
+        public String getGameModelId() {
+            return CleanGarbageModel.MODEL_CLEAN_GARBAGE_ID;
+        }
+
+        @Override
+        protected String getGameModeTitle() {
+            return app.TEXTS.get("labelModel_typeB");
+        }
+
+        @Override
+        protected boolean isShowBestTime() {
+            return true;
+        }
+
+        @Override
+        protected void fillParamsTable(LightBlocksGame app) {
+            garbageSizeSlider = new TouchableSlider(1, 16, 1, false, app.skin);
+            garbageSizeSlider.setValue(5);
+
+            row().pad(40, 20, 0, 20);
+            ScaledLabel introLabel = new ScaledLabel(app.TEXTS.get("goalModelCleanGarbage"), app.skin,
+                LightBlocksGame.SKIN_FONT_REG, .75f);
+            introLabel.setWrap(true);
+            introLabel.setAlignment(Align.center);
+            add(introLabel).bottom().fillX().expandX();
+
+            params.row().padTop(15);
+            params.add(getGarbagParamTable()).expand().fill();
+
+            super.fillParamsTable(app);
+
+            menuScreen.addFocusableActor(playButton);
+        }
+
+        private Table getGarbagParamTable() {
+            final ScaledLabel beginningLevelLabel = new ScaledLabel("5 lines", app.skin, LightBlocksGame.SKIN_FONT_TITLE);
+            garbageSizeSlider.addListener(new ChangeListener() {
+                @Override
+                public void changed(ChangeEvent event, Actor actor) {
+                    beginningLevelLabel.setText(String.valueOf((int)garbageSizeSlider.getValue()) + " lines");
+                }
+            });
+
+            Table paramTable = new Table();
+            paramTable.row();
+            paramTable.add(garbageSizeSlider).minHeight(30).minWidth(200).right().fill();
+            paramTable.add(beginningLevelLabel).left().spaceLeft(10).minWidth(beginningLevelLabel.getPrefWidth() * 1.1f);
+
+            return paramTable;
+        }
+
+        @Override
+        protected InitGameParameters getInitGameParameters() {
+            InitGameParameters initGameParametersParams = new InitGameParameters();
+            initGameParametersParams.setGameMode(InitGameParameters.GameMode.Clean);
+            initGameParametersParams.setBeginningLevel(0);
+            initGameParametersParams.setInputKey(PlayScreenInput.KEY_KEYORTOUCH);
+            initGameParametersParams.setInitialGarbage((int)garbageSizeSlider.getValue());
+            return initGameParametersParams;
+        }
+
+        @Override
+        protected int getMaxBeginningValue() {
+            return 0;
+        }
+
+        @Override
+        protected void savePreselectionSettings() {
+            // es gibt keine
         }
     }
 

--- a/core/src/de/golfgl/lightblocks/menu/SinglePlayerScreen.java
+++ b/core/src/de/golfgl/lightblocks/menu/SinglePlayerScreen.java
@@ -66,6 +66,7 @@ public class SinglePlayerScreen extends AbstractMenuDialog {
         modePager.addPage(new MissionChooseGroup(this, app));
         modePager.addPage(new SimpleGameModeGroup.MarathonGroup(this, app));
         modePager.addPage(new SimpleGameModeGroup.PracticeModeGroup(this, app));
+        modePager.addPage(new SimpleGameModeGroup.CleanGarbageModeGroup(this, app));
         modePager.addPage(new SimpleGameModeGroup.SprintModeGroup(this, app));
         modePager.addPage(new SimpleGameModeGroup.ModernFreezeModeGroup(this, app));
         modePager.addListener(new ChangeListener() {

--- a/core/src/de/golfgl/lightblocks/model/CleanGarbageModel.java
+++ b/core/src/de/golfgl/lightblocks/model/CleanGarbageModel.java
@@ -1,0 +1,59 @@
+package de.golfgl.lightblocks.model;
+
+import com.badlogic.gdx.utils.Json;
+import com.badlogic.gdx.utils.JsonValue;
+
+import de.golfgl.lightblocks.state.InitGameParameters;
+
+public class CleanGarbageModel extends GameModel {
+  public static final String MODEL_CLEAN_GARBAGE_ID = "cleanGarbage";
+
+  private int modeType;
+
+  @Override
+  public String getIdentifier() {
+    return MODEL_CLEAN_GARBAGE_ID;
+  }
+
+  @Override
+  public String getGoalDescription()
+  {
+    return "goalClean";
+  }
+
+  @Override
+  public InitGameParameters getInitParameters() {
+    InitGameParameters retVal = new InitGameParameters();
+
+    retVal.setBeginningLevel(getScore().getStartingLevel());
+    retVal.setInputKey(inputTypeKey);
+    retVal.setGameMode(InitGameParameters.GameMode.Clean);
+    retVal.setModeType(modeType);
+
+    return retVal;
+  }
+
+  @Override
+  protected void activeTetrominoDropped() {
+    if (getScore().getClearedLines() > 0 && !getGameboard().hasGarbage())
+      setGameOverWon(IGameModelListener.MotivationTypes.gameSuccess);
+  }
+
+
+  @Override
+  public void startNewGame(InitGameParameters newGameParams) {
+    modeType = newGameParams.getModeType();
+    super.startNewGame(newGameParams);
+  }
+
+
+  @Override
+  public void read(Json json, JsonValue jsonData) {
+    super.read(json, jsonData);
+
+    // Der Wert darf nicht wieder gespeichert werden, um die Garbage nicht bei jedem Laden
+    // wieder einzufügen
+    int insertGarbage = jsonData.getInt("initialGarbage", 0);
+    getGameboard().initGarbage(insertGarbage);
+  }
+}

--- a/core/src/de/golfgl/lightblocks/model/GameModel.java
+++ b/core/src/de/golfgl/lightblocks/model/GameModel.java
@@ -786,6 +786,9 @@ public abstract class GameModel implements Json.Serializable, AiAcessibleGameMod
     public void startNewGame(InitGameParameters newGameParams) {
         gameboard = new Gameboard();
         initGameScore(newGameParams.getBeginningLevel());
+        if (newGameParams.getGameMode() == InitGameParameters.GameMode.Clean) {
+            getGameboard().initGarbage(newGameParams.getInitialGarbage());
+        }
         setCurrentSpeed();
         inputTypeKey = newGameParams.getInputKey();
 

--- a/core/src/de/golfgl/lightblocks/state/InitGameParameters.java
+++ b/core/src/de/golfgl/lightblocks/state/InitGameParameters.java
@@ -3,6 +3,7 @@ package de.golfgl.lightblocks.state;
 import de.golfgl.lightblocks.backend.MatchEntity;
 import de.golfgl.lightblocks.input.InputIdentifier;
 import de.golfgl.lightblocks.model.BackendBattleModel;
+import de.golfgl.lightblocks.model.CleanGarbageModel;
 import de.golfgl.lightblocks.model.DeviceMultiplayerModel;
 import de.golfgl.lightblocks.model.GameModel;
 import de.golfgl.lightblocks.model.MarathonModel;
@@ -30,6 +31,7 @@ public class InitGameParameters {
     private int beginningLevel;
     private String missionId;
     private GameMode gameMode;
+    private int initialGarbage;
     private int modeType;
 
     // for Multiplayer
@@ -77,6 +79,16 @@ public class InitGameParameters {
 
     public void setGameMode(GameMode gameMode) {
         this.gameMode = gameMode;
+    }
+
+    public int getInitialGarbage()
+    {
+        return initialGarbage;
+    }
+
+    public void setInitialGarbage(int initialGarbage)
+    {
+        this.initialGarbage = initialGarbage;
     }
 
     public AbstractMultiplayerRoom getMultiplayerRoom() {
@@ -158,6 +170,8 @@ public class InitGameParameters {
                 return new BackendBattleModel();
             case ModernFreeze:
                 return new ModernFreezeModel();
+            case Clean:
+                return new CleanGarbageModel();
             case DeviceMultiplayer:
                 return new DeviceMultiplayerModel();
             case ServerMultiplayer:
@@ -166,5 +180,5 @@ public class InitGameParameters {
         throw new IllegalStateException("Unsupported game mode");
     }
 
-    public enum GameMode {Multiplayer, Marathon, Tutorial, Sprint, MarathonRetro89, Practice, TurnbasedBattle, ModernFreeze, ServerMultiplayer, DeviceMultiplayer}
+    public enum GameMode {Multiplayer, Marathon, Tutorial, Sprint, MarathonRetro89, Practice, TurnbasedBattle, ModernFreeze, ServerMultiplayer, DeviceMultiplayer, Clean}
 }


### PR DESCRIPTION
I love cleaning garbase as in `typeB_1?` missions. So I added new Single player mode "Clean Garbage". One can select number of garbage lines.

Introduced new class `CleanGrabageModel` because `CleanModel` extends `MissionModel` and can't be used as a single player mode.

![Clean Garbage mode Screenshot](https://github.com/user-attachments/assets/4de418de-7e3d-4ebe-812f-1ee849f4524e)
